### PR TITLE
Fix Client.request returning raw strings instead of dicts

### DIFF
--- a/openapi_python_sdk/client.py
+++ b/openapi_python_sdk/client.py
@@ -3,6 +3,8 @@ from typing import Any, Dict
 
 import httpx
 
+import json
+
 OAUTH_BASE_URL = "https://oauth.openapi.it"
 TEST_OAUTH_BASE_URL = "https://test.oauth.openapi.it"
 
@@ -62,10 +64,17 @@ class Client:
         payload = payload or {}
         params = params or {}
         url = url or ""
-        return self.client.request(
+        data = self.client.request(
             method=method,
             url=url,
             headers=self.headers,
             json=payload,
             params=params,
         ).json()
+
+        if isinstance(data,str):
+            try:
+                data=json.loads(data)
+            except json.JSONDecodeError:
+                pass
+        return data


### PR DESCRIPTION
#6  I noticed that Client.request() sometimes returns double-encoded JSON as a raw string instead of a parsed dictionary. This forces users (especially in Flask apps) to manually write json.loads(resp) repeatedly, which is a bit of a hassle.

This PR fixes that by ensuring we automatically decode the string into a dict under the hood, saving everyone from writing extra boilerplate.

Let me know if you need any changes!