### PR TITLE
Fix #4 - Handle thread safety for shared clients (Celery fixes)

### DIFF
--- a/openapi_python_sdk/client.py
+++ b/openapi_python_sdk/client.py
@@ -1,4 +1,5 @@
 import json
+import threading
 from typing import Any, Dict
 
 import httpx
@@ -15,12 +16,32 @@ class Client:
     """
 
     def __init__(self, token: str, client: Any = None, timeout: float = 30.0):
-        self.client = client if client is not None else httpx.Client(timeout=timeout)
+        self._client = client
+        self._thread_local = threading.local()
+        self.timeout = timeout
         self.auth_header: str = f"Bearer {token}"
         self.headers: Dict[str, str] = {
             "Authorization": self.auth_header,
             "Content-Type": "application/json",
         }
+
+    @property
+    def client(self) -> Any:
+        """
+        Thread-safe access to the underlying HTTP client.
+        If a custom client was provided at initialization, it is returned.
+        Otherwise, a thread-local httpx.Client is created and returned.
+        """
+        if self._client is not None:
+            return self._client
+        
+        if not hasattr(self._thread_local, "client"):
+            self._thread_local.client = httpx.Client(timeout=self.timeout)
+        return self._thread_local.client
+
+    @client.setter
+    def client(self, value: Any):
+        self._client = value
 
     def __enter__(self):
         """Enable use as a synchronous context manager."""

--- a/openapi_python_sdk/client.py
+++ b/openapi_python_sdk/client.py
@@ -34,7 +34,7 @@ class Client:
         """
         if self._client is not None:
             return self._client
-        
+
         if not hasattr(self._thread_local, "client"):
             self._thread_local.client = httpx.Client(timeout=self.timeout)
         return self._thread_local.client

--- a/openapi_python_sdk/oauth_client.py
+++ b/openapi_python_sdk/oauth_client.py
@@ -1,4 +1,5 @@
 import base64
+import threading
 from typing import Any, Dict, List
 
 import httpx
@@ -13,7 +14,9 @@ class OauthClient:
     """
 
     def __init__(self, username: str, apikey: str, test: bool = False, client: Any = None, timeout: float = 30.0):
-        self.client = client if client is not None else httpx.Client(timeout=timeout)
+        self._client = client
+        self._thread_local = threading.local()
+        self.timeout = timeout
         self.url: str = TEST_OAUTH_BASE_URL if test else OAUTH_BASE_URL
         self.auth_header: str = (
             "Basic " + base64.b64encode(f"{username}:{apikey}".encode("utf-8")).decode()
@@ -22,6 +25,24 @@ class OauthClient:
             "Authorization": self.auth_header,
             "Content-Type": "application/json",
         }
+
+    @property
+    def client(self) -> Any:
+        """
+        Thread-safe access to the underlying HTTP client.
+        If a custom client was provided at initialization, it is returned.
+        Otherwise, a thread-local httpx.Client is created and returned.
+        """
+        if self._client is not None:
+            return self._client
+        
+        if not hasattr(self._thread_local, "client"):
+            self._thread_local.client = httpx.Client(timeout=self.timeout)
+        return self._thread_local.client
+
+    @client.setter
+    def client(self, value: Any):
+        self._client = value
 
     def __enter__(self):
         """Enable use as a synchronous context manager."""

--- a/openapi_python_sdk/oauth_client.py
+++ b/openapi_python_sdk/oauth_client.py
@@ -35,7 +35,7 @@ class OauthClient:
         """
         if self._client is not None:
             return self._client
-        
+
         if not hasattr(self._thread_local, "client"):
             self._thread_local.client = httpx.Client(timeout=self.timeout)
         return self._thread_local.client

--- a/openapi_python_sdk/oauth_client.py
+++ b/openapi_python_sdk/oauth_client.py
@@ -35,7 +35,6 @@ class OauthClient:
         """
         if self._client is not None:
             return self._client
-
         if not hasattr(self._thread_local, "client"):
             self._thread_local.client = httpx.Client(timeout=self.timeout)
         return self._thread_local.client

--- a/tests/test_thread_safety.py
+++ b/tests/test_thread_safety.py
@@ -1,0 +1,56 @@
+import threading
+import unittest
+from openapi_python_sdk import Client, OauthClient
+import httpx
+
+class TestThreadSafety(unittest.TestCase):
+    def test_oauth_client_thread_safety(self):
+        oauth = OauthClient(username="user", apikey="key")
+        
+        clients = []
+        def get_client():
+            clients.append(oauth.client)
+            
+        threads = [threading.Thread(target=get_client) for _ in range(5)]
+        for t in threads: t.start()
+        for t in threads: t.join()
+        
+        # Each thread should have gotten a unique client instance
+        self.assertEqual(len(clients), 5)
+        self.assertEqual(len(set(id(c) for c in clients)), 5)
+
+    def test_client_thread_safety(self):
+        client = Client(token="tok")
+        
+        clients = []
+        def get_client():
+            clients.append(client.client)
+            
+        threads = [threading.Thread(target=get_client) for _ in range(5)]
+        for t in threads: t.start()
+        for t in threads: t.join()
+        
+        # Each thread should have gotten a unique client instance
+        self.assertEqual(len(clients), 5)
+        self.assertEqual(len(set(id(c) for c in clients)), 5)
+
+    def test_shared_client_injection_still_works(self):
+        # If we explicitly pass a client, it SHOULD be shared (backward compatibility)
+        shared_engine = httpx.Client()
+        oauth = OauthClient(username="user", apikey="key", client=shared_engine)
+        
+        clients = []
+        def get_client():
+            clients.append(oauth.client)
+            
+        threads = [threading.Thread(target=get_client) for _ in range(5)]
+        for t in threads: t.start()
+        for t in threads: t.join()
+        
+        # All threads should have the SAME instance because it was injected
+        self.assertEqual(len(clients), 5)
+        self.assertEqual(len(set(id(c) for c in clients)), 1)
+        self.assertEqual(id(clients[0]), id(shared_engine))
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_thread_safety.py
+++ b/tests/test_thread_safety.py
@@ -6,30 +6,34 @@ import httpx
 class TestThreadSafety(unittest.TestCase):
     def test_oauth_client_thread_safety(self):
         oauth = OauthClient(username="user", apikey="key")
-        
+
         clients = []
         def get_client():
             clients.append(oauth.client)
-            
+
         threads = [threading.Thread(target=get_client) for _ in range(5)]
-        for t in threads: t.start()
-        for t in threads: t.join()
-        
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
         # Each thread should have gotten a unique client instance
         self.assertEqual(len(clients), 5)
         self.assertEqual(len(set(id(c) for c in clients)), 5)
 
     def test_client_thread_safety(self):
         client = Client(token="tok")
-        
+
         clients = []
         def get_client():
             clients.append(client.client)
-            
+
         threads = [threading.Thread(target=get_client) for _ in range(5)]
-        for t in threads: t.start()
-        for t in threads: t.join()
-        
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
         # Each thread should have gotten a unique client instance
         self.assertEqual(len(clients), 5)
         self.assertEqual(len(set(id(c) for c in clients)), 5)
@@ -38,15 +42,17 @@ class TestThreadSafety(unittest.TestCase):
         # If we explicitly pass a client, it SHOULD be shared (backward compatibility)
         shared_engine = httpx.Client()
         oauth = OauthClient(username="user", apikey="key", client=shared_engine)
-        
+
         clients = []
         def get_client():
             clients.append(oauth.client)
-            
+
         threads = [threading.Thread(target=get_client) for _ in range(5)]
-        for t in threads: t.start()
-        for t in threads: t.join()
-        
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
         # All threads should have the SAME instance because it was injected
         self.assertEqual(len(clients), 5)
         self.assertEqual(len(set(id(c) for c in clients)), 1)

--- a/tests/test_thread_safety.py
+++ b/tests/test_thread_safety.py
@@ -1,7 +1,10 @@
 import threading
 import unittest
-from openapi_python_sdk import Client, OauthClient
+
 import httpx
+
+from openapi_python_sdk import Client, OauthClient
+
 
 class TestThreadSafety(unittest.TestCase):
     def test_oauth_client_thread_safety(self):


### PR DESCRIPTION
hey @francescobianco ,

this is fix for #4 

I’ve been looking into the issue where OauthClient was blowing up when shared across Celery workers, and it’s basically down to how we were handling the internal httpx client. Since we were initializing it once in the constructor, every single worker thread was trying to squeeze through the same connection pool at the same time. That’s why users were seeing those random failures and corrupted data - the internal state just couldn't handle that much concurrent noise.

To fix this without making everyone rewrite their Celery tasks, I moved the internal client over to a property backed by `threading.local()`. So now, even if you define the client once at the top of your file, each worker thread will lazily spin up its own private connection the first time it actually needs to make a call. It completely solves the thread-safety headache while keeping the code looking exactly the same from the outside.

One thing I wanted to be careful about was not breaking the custom client injection. I know some people pass in their own sessions for custom retries or proxies, so I made sure that if you explicitly pass a `client` in the constructor, it still uses that exact object across all threads. This keeps things backward compatible for power users while making the default behavior safe for everyone else.

I also threw in a new test file, `tests/test_thread_safety.py`, which just fires off a bunch of threads and makes sure they aren't stepping on each other's toes by checking that they each get a unique client instance. All the original tests pass too, since the mocks still hook into the property correctly.

Let me know what you think!
