### PR TITLE
Add configurable network timeouts to all HTTP clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,18 @@ session.mount("https://", adapter)
 client = Client("token", client=session)
 ```
 
+### Configuring Network Timeouts
+
+By default, the SDK uses a 30-second timeout for all network requests to avoid hanging on slow network connections or heavy API operations. 
+
+You can easily override it passing a `timeout` explicitly during initialization to all client variants:
+
+```python
+from openapi_python_sdk import Client
+
+client = Client(token="token", timeout=60.0) # 60 seconds
+```
+
 ## Async Usage
 
 The SDK provides `AsyncClient` and `AsyncOauthClient` for use with asynchronous frameworks like FastAPI or `aiohttp`.

--- a/docs/readme-pypi.md
+++ b/docs/readme-pypi.md
@@ -60,6 +60,16 @@ resp = client.request(
 )
 ```
 
+### Configuring Network Timeouts
+
+By default, the SDK uses a 30-second timeout for all network requests. You can easily override it passing a `timeout` explicitly during initialization:
+
+```python
+from openapi_python_sdk.client import Client
+
+client = Client(token="token", timeout=60.0) # 60 seconds
+```
+
 ## Testing
 
 ```bash
@@ -71,7 +81,7 @@ pytest
 
 | Method | Description |
 |---|---|
-| `OauthClient(username, apikey, test=False)` | Initialize the OAuth client. Set `test=True` for sandbox. |
+| `OauthClient(username, apikey, test=False, timeout=30.0)` | Initialize the OAuth client. Set `test=True` for sandbox. |
 | `create_token(scopes, ttl)` | Create a bearer token for the given scopes and TTL (seconds). |
 | `get_token(scope)` | Retrieve an existing token by scope. |
 | `delete_token(id)` | Revoke a token by ID. |
@@ -82,7 +92,7 @@ pytest
 
 | Method | Description |
 |---|---|
-| `Client(token)` | Initialize the client with a bearer token. |
+| `Client(token, timeout=30.0)` | Initialize the client with a bearer token. |
 | `request(method, url, payload, params)` | Execute an HTTP request against any Openapi endpoint. |
 
 ## Links

--- a/openapi_python_sdk/async_client.py
+++ b/openapi_python_sdk/async_client.py
@@ -10,8 +10,8 @@ class AsyncClient:
     Suitable for use with FastAPI, aiohttp, etc.
     """
 
-    def __init__(self, token: str, client: Any = None):
-        self.client = client if client is not None else httpx.AsyncClient()
+    def __init__(self, token: str, client: Any = None, timeout: float = 30.0):
+        self.client = client if client is not None else httpx.AsyncClient(timeout=timeout)
         self.auth_header: str = f"Bearer {token}"
         self.headers: Dict[str, str] = {
             "Authorization": self.auth_header,

--- a/openapi_python_sdk/async_oauth_client.py
+++ b/openapi_python_sdk/async_oauth_client.py
@@ -12,8 +12,8 @@ class AsyncOauthClient:
     Suitable for use with FastAPI, aiohttp, etc.
     """
 
-    def __init__(self, username: str, apikey: str, test: bool = False, client: Any = None):
-        self.client = client if client is not None else httpx.AsyncClient()
+    def __init__(self, username: str, apikey: str, test: bool = False, client: Any = None, timeout: float = 30.0):
+        self.client = client if client is not None else httpx.AsyncClient(timeout=timeout)
         self.url: str = TEST_OAUTH_BASE_URL if test else OAUTH_BASE_URL
         self.auth_header: str = (
             "Basic " + base64.b64encode(f"{username}:{apikey}".encode("utf-8")).decode()

--- a/openapi_python_sdk/client.py
+++ b/openapi_python_sdk/client.py
@@ -14,8 +14,8 @@ class Client:
     Synchronous client for making authenticated requests to Openapi endpoints.
     """
 
-    def __init__(self, token: str, client: Any = None):
-        self.client = client if client is not None else httpx.Client()
+    def __init__(self, token: str, client: Any = None, timeout: float = 30.0):
+        self.client = client if client is not None else httpx.Client(timeout=timeout)
         self.auth_header: str = f"Bearer {token}"
         self.headers: Dict[str, str] = {
             "Authorization": self.auth_header,

--- a/openapi_python_sdk/oauth_client.py
+++ b/openapi_python_sdk/oauth_client.py
@@ -12,8 +12,8 @@ class OauthClient:
     Synchronous client for handling Openapi authentication and token management.
     """
 
-    def __init__(self, username: str, apikey: str, test: bool = False, client: Any = None):
-        self.client = client if client is not None else httpx.Client()
+    def __init__(self, username: str, apikey: str, test: bool = False, client: Any = None, timeout: float = 30.0):
+        self.client = client if client is not None else httpx.Client(timeout=timeout)
         self.url: str = TEST_OAUTH_BASE_URL if test else OAUTH_BASE_URL
         self.auth_header: str = (
             "Basic " + base64.b64encode(f"{username}:{apikey}".encode("utf-8")).decode()


### PR DESCRIPTION
ref #18 
This PR introduces a simple, built-in way for developers to configure network timeouts across all the SDK clients (`Client`, `AsyncClient`, `OauthClient`, and `AsyncOauthClient`).

### Why is this necessary?
Right now, the SDK uses the default 5-second timeout imposed by `httpx`. While that's fine for simple requests, it's a bit too strict for heavy API operations (like generating large PDFs or querying massive datasets) and causes perfectly valid requests to unexpectedly crash with a `TimeoutException`. 

Previously, the only way to avoid this was to build a completely custom `httpx.Client(timeout=...)` object and pass it in during initialization, which was a lot of unnecessary boilerplate for a very common need.

### How was this implemented? Let's break down the changes:
1. **Added a `timeout` argument**: I added `timeout: float = 30.0` directly to the `__init__` methods of all four client classes. 
2. **Passed it down natively**: The param is passed directly into `httpx.Client(timeout=timeout)` and `httpx.AsyncClient(timeout=timeout)`.
3. **Smarter default**: Upped the default SDK timeout from 5 seconds to a much safer **30 seconds** to prevent crashes on slower endpoints without hanging forever.
4. **Preserved backward compatibility**: Check out the logic: `self.client = client if client is not None else httpx.Client(timeout=timeout)`. We only apply this timeout if a user *isn't* passing in their own custom HTTP client config. This guarantees we don't break existing custom transport layers.
5. **Updated Documentation**: 
   - Appended a new `Configuring Network Timeouts` snippet to the `README.md`.
   - Replicated those usage snippets to `docs/readme-pypi.md` and updated the Markdown API tables to reflect the new `timeout=30.0` signature.

### Testing
- Ran the internal test suite via `poetry run pytest` and verified all 18 existing test cases still pass perfectly with these changes! 
